### PR TITLE
docs: Include setup.py step to setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Note that a subset of the prompts are still *Work in Progress*. You'll find the 
 1. Download the repo
 2. Navigate to root directory of the repo
 3. Install requirements with `pip install -r requirements.txt` in a Python 3.7 environment
-4. Run `python setup.py develop` to install the `promptsource` module
+4. Run `pip install -e .` to install the `promptsource` module
 
 ## Running
 You can browse through existing prompts on the [hosted versiond of Promptsource](https://bigscience.huggingface.co/promptsource).

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Note that a subset of the prompts are still *Work in Progress*. You'll find the 
 1. Download the repo
 2. Navigate to root directory of the repo
 3. Install requirements with `pip install -r requirements.txt` in a Python 3.7 environment
+4. Run `python setup.py develop` to install the `promptsource` module
 
 ## Running
 You can browse through existing prompts on the [hosted versiond of Promptsource](https://bigscience.huggingface.co/promptsource).


### PR DESCRIPTION
Not sure if this is needed for everyone, but at least in my case not running this installation step made the streamlit to fail (not found module).

Also not sure if using `develop` is the right choice. I'd be happy to edit this PR with your suggestions!